### PR TITLE
Bump dotenv from 16.5.0 to 17.0.0

Bumps [dotenv](https://github.com/motdotla/dotenv) from 16.5.0 to 17.0.0.
- [Changelog](https://github.com/motdotla/dotenv/blob/master/CHANGELOG.md)
- [Commits](https://github.com/motdotla/dotenv/compare/v16.5.0...v17.0.0)

---
updated-dependencies:
- dependency-name: dotenv
  dependency-version: 17.0.0
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "cuss": "2.2.0",
         "dayjs": "^1.11.13",
         "dereference-json-schema": "^0.2.1",
-        "dotenv": "^16.4.7",
+        "dotenv": "^17.0.0",
         "escape-string-regexp": "5.0.0",
         "express": "^5.1.0",
         "fastest-levenshtein": "1.0.16",
@@ -7299,10 +7299,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
-      "license": "BSD-2-Clause",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.0.0.tgz",
+      "integrity": "sha512-A0BJ5lrpJVSfnMMXjmeO0xUnoxqsBHWCoqqTnGwGYVdnctqXXUEhJOO7LxmgxJon9tEZFGpe0xPRX0h2v3AANQ==",
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -270,7 +270,7 @@
     "cuss": "2.2.0",
     "dayjs": "^1.11.13",
     "dereference-json-schema": "^0.2.1",
-    "dotenv": "^16.4.7",
+    "dotenv": "^17.0.0",
     "escape-string-regexp": "5.0.0",
     "express": "^5.1.0",
     "fastest-levenshtein": "1.0.16",


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
